### PR TITLE
Fix sidebar navigation layering and hero background path

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <canvas id="spotlight" class="spotlight"></canvas>
 
         <!-- Sidebar (colorful + toggleable) -->
-    <aside class="nav-rail fixed left-0 top-0 h-full z-20">
+    <aside class="nav-rail fixed left-0 top-0 h-full z-50">
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
         <a href="#home" class="nav-item is-active" aria-label="Home" style="--accent:#60A5FA">
@@ -86,7 +86,7 @@
 
     <main id="home" class="pl-rail relative z-10">
       <section class="hero-section relative min-h-[80vh] grid place-items-center">
-        <div class="hero-sun" style="--hero-img: url('assets/images/background.png')"></div>
+        <div class="hero-sun" style="--hero-img: url('../images/background.png')"></div>
 
         <!-- HERO CONTENT -->
         <div class="max-w-6xl mx-auto px-6 text-center relative z-20">

--- a/pages/bonuses.html
+++ b/pages/bonuses.html
@@ -33,7 +33,7 @@
     <canvas id="spotlight" class="spotlight"></canvas>
 
         <!-- Sidebar (colorful + toggleable) -->
-    <aside class="nav-rail fixed left-0 top-0 h-full z-20">
+    <aside class="nav-rail fixed left-0 top-0 h-full z-50">
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
         <a href="../index.html#home" class="nav-item" aria-label="Home" style="--accent:#60A5FA">

--- a/pages/content.html
+++ b/pages/content.html
@@ -33,7 +33,7 @@
     <canvas id="spotlight" class="spotlight"></canvas>
 
         <!-- Sidebar (colorful + toggleable) -->
-    <aside class="nav-rail fixed left-0 top-0 h-full z-20">
+    <aside class="nav-rail fixed left-0 top-0 h-full z-50">
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
         <a href="../index.html#home" class="nav-item" aria-label="Home" style="--accent:#60A5FA">

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -33,7 +33,7 @@
     <canvas id="spotlight" class="spotlight"></canvas>
 
         <!-- Sidebar (colorful + toggleable) -->
-    <aside class="nav-rail fixed left-0 top-0 h-full z-20">
+    <aside class="nav-rail fixed left-0 top-0 h-full z-50">
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
         <a href="../index.html#home" class="nav-item" aria-label="Home" style="--accent:#60A5FA">

--- a/pages/rewards.html
+++ b/pages/rewards.html
@@ -33,7 +33,7 @@
     <canvas id="spotlight" class="spotlight"></canvas>
 
         <!-- Sidebar (colorful + toggleable) -->
-    <aside class="nav-rail fixed left-0 top-0 h-full z-20">
+    <aside class="nav-rail fixed left-0 top-0 h-full z-50">
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
         <a href="../index.html#home" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
@@ -90,7 +90,7 @@
     <!-- HERO: behind heading + cards -->
     <div class="absolute inset-0 -z-10 pointer-events-none">
       <!-- swap background.png for your sun image -->
-      <div class="hero-sun" style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+      <div class="hero-sun" style="--hero-img: url('../images/background.png'); --sun-size: min(1200px,95vw)"></div>
       <div class="hero-fade"></div>
     </div>
 

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -1,6 +1,6 @@
 <main id="home" class="pl-rail relative z-10">
       <section class="hero-section relative min-h-[80vh] grid place-items-center">
-        <div class="hero-sun" style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"></div>
+        <div class="hero-sun" style="--hero-img: url('../images/background.png')"></div>
 
         <!-- HERO CONTENT -->
         <div class="max-w-6xl mx-auto px-6 text-center relative z-20">

--- a/templates/pages/pages/rewards.html
+++ b/templates/pages/pages/rewards.html
@@ -4,7 +4,7 @@
     <!-- HERO: behind heading + cards -->
     <div class="absolute inset-0 -z-10 pointer-events-none">
       <!-- swap background.png for your sun image -->
-      <div class="hero-sun" style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+      <div class="hero-sun" style="--hero-img: url('../images/background.png'); --sun-size: min(1200px,95vw)"></div>
       <div class="hero-fade"></div>
     </div>
 

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -1,5 +1,5 @@
     <!-- Sidebar (colorful + toggleable) -->
-    <aside class="nav-rail fixed left-0 top-0 h-full z-20">
+    <aside class="nav-rail fixed left-0 top-0 h-full z-50">
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
 {{NAV_ITEMS}}


### PR DESCRIPTION
## Summary
- raise the sidebar navigation z-index so it renders above the header on every page
- load the hero background via a stylesheet-relative path on the home and rewards pages (and templates) to eliminate 404s

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9857118dc8332a6fa9684f766bccb