### PR TITLE
Improve mobile nav and stabilize hero background

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -291,6 +291,89 @@ footer.pl-rail {
   box-shadow: 0 0 22px rgba(236, 72, 153, 0.55);
 }
 
+@media (max-width: 767px) {
+  body {
+    padding-bottom: 5.5rem;
+    padding-bottom: calc(5.5rem + env(safe-area-inset-bottom));
+  }
+
+  .nav-rail.fixed {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: auto;
+    width: 100%;
+    --rail-w: 100%;
+    padding: 0 1rem;
+    padding-bottom: 0.75rem;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+  }
+
+  .nav-rail .rail {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 100%;
+    padding: 0.5rem 0.85rem;
+    padding-bottom: 0.75rem;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+    border-radius: 1.25rem 1.25rem 0 0;
+    gap: 0;
+  }
+
+  .nav-rail .rail-active {
+    display: none;
+  }
+
+  .nav-rail .rail-toggle {
+    display: none;
+  }
+
+  .nav-rail .nav-item,
+  .nav-rail.collapsed .nav-item {
+    flex: 1 1 0;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    margin: 0;
+    padding: 0.5rem 0.25rem;
+    border-radius: 16px;
+  }
+
+  .nav-rail .nav-bubble {
+    margin-right: 0;
+  }
+
+  .nav-rail .nav-item .nav-label,
+  .nav-rail.collapsed .nav-item .nav-label {
+    max-width: none;
+    opacity: 1;
+    transform: none;
+    margin-left: 0;
+    font-size: 0.65rem;
+  }
+
+  header.pl-rail,
+  main.pl-rail,
+  footer.pl-rail {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  main.pl-rail {
+    padding-bottom: 5rem;
+    padding-bottom: calc(5rem + env(safe-area-inset-bottom));
+  }
+
+  footer.pl-rail {
+    padding-bottom: 4rem;
+    padding-bottom: calc(4rem + env(safe-area-inset-bottom));
+  }
+}
+
 @keyframes cue-gradient {
   0% {
     background-position: 0% 50%;
@@ -1247,8 +1330,8 @@ footer.pl-rail {
 }
 
 /* ===== Utility ===== */
-@media (max-width: 639px) {
+@media (max-width: 767px) {
   :root {
-    --rail-pad: 4rem;
+    --rail-pad: 1.5rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -86,7 +86,11 @@
 
     <main id="home" class="pl-rail relative z-10">
       <section class="hero-section relative min-h-[80vh] grid place-items-center">
-        <div class="hero-sun" style="--hero-img: url('assets/images/background.png')"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="assets/images/background.png"
+          style="--hero-img: url('assets/images/background.png')"
+        ></div>
 
         <!-- HERO CONTENT -->
         <div class="max-w-6xl mx-auto px-6 text-center relative z-20">

--- a/pages/bonuses.html
+++ b/pages/bonuses.html
@@ -87,7 +87,11 @@
     <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="absolute inset-0 -z-10 pointer-events-none">
-          <div class="hero-sun" style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="../assets/images/background.png"
+          style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+        ></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">

--- a/pages/content.html
+++ b/pages/content.html
@@ -87,7 +87,11 @@
     <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="absolute inset-0 -z-10 pointer-events-none">
-          <div class="hero-sun" style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="../assets/images/background.png"
+          style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+        ></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -87,7 +87,11 @@
     <main class="pl-rail relative z-10">
       <section class="relative pt-10 pb-14 hero-section">
         <div class="absolute inset-0 -z-10 pointer-events-none">
-          <div class="hero-sun" style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="../assets/images/background.png"
+          style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+        ></div>
           <div class="hero-fade"></div>
         </div>
         <div class="max-w-7xl mx-auto px-6 relative z-10">

--- a/pages/rewards.html
+++ b/pages/rewards.html
@@ -90,7 +90,11 @@
     <!-- HERO: behind heading + cards -->
     <div class="absolute inset-0 -z-10 pointer-events-none">
       <!-- swap background.png for your sun image -->
-      <div class="hero-sun" style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+      <div
+        class="hero-sun"
+        data-hero-img="../assets/images/background.png"
+        style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+      ></div>
       <div class="hero-fade"></div>
     </div>
 

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -1,6 +1,10 @@
 <main id="home" class="pl-rail relative z-10">
       <section class="hero-section relative min-h-[80vh] grid place-items-center">
-        <div class="hero-sun" style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="{{ASSET_BASE}}/images/background.png"
+          style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
+        ></div>
 
         <!-- HERO CONTENT -->
         <div class="max-w-6xl mx-auto px-6 text-center relative z-20">

--- a/templates/pages/pages/bonuses.html
+++ b/templates/pages/pages/bonuses.html
@@ -1,7 +1,11 @@
 <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="absolute inset-0 -z-10 pointer-events-none">
-          <div class="hero-sun" style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="{{ASSET_BASE}}/images/background.png"
+          style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+        ></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">

--- a/templates/pages/pages/content.html
+++ b/templates/pages/pages/content.html
@@ -1,7 +1,11 @@
 <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="absolute inset-0 -z-10 pointer-events-none">
-          <div class="hero-sun" style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="{{ASSET_BASE}}/images/background.png"
+          style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+        ></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">

--- a/templates/pages/pages/leaderboard.html
+++ b/templates/pages/pages/leaderboard.html
@@ -1,7 +1,11 @@
 <main class="pl-rail relative z-10">
       <section class="relative pt-10 pb-14 hero-section">
         <div class="absolute inset-0 -z-10 pointer-events-none">
-          <div class="hero-sun" style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+        <div
+          class="hero-sun"
+          data-hero-img="{{ASSET_BASE}}/images/background.png"
+          style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+        ></div>
           <div class="hero-fade"></div>
         </div>
         <div class="max-w-7xl mx-auto px-6 relative z-10">

--- a/templates/pages/pages/rewards.html
+++ b/templates/pages/pages/rewards.html
@@ -4,7 +4,11 @@
     <!-- HERO: behind heading + cards -->
     <div class="absolute inset-0 -z-10 pointer-events-none">
       <!-- swap background.png for your sun image -->
-      <div class="hero-sun" style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+      <div
+        class="hero-sun"
+        data-hero-img="{{ASSET_BASE}}/images/background.png"
+        style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+      ></div>
       <div class="hero-fade"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- restyle the nav rail into a fixed bottom bar on narrow screens and adjust surrounding layout spacing
- update the nav rail script to respect the mobile layout and keep the rail padding consistent across breakpoints
- attach explicit hero background paths and normalize them in script so the background image loads on every page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9958c1f60833292575e10be199e4d