### PR TITLE
Fix hero backgrounds and improve mobile layout

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -372,6 +372,15 @@ footer.pl-rail {
     padding-bottom: 4rem;
     padding-bottom: calc(4rem + env(safe-area-inset-bottom));
   }
+
+  .hero-section .hero-sun,
+  .hero-section .hero-fade {
+    display: none;
+  }
+
+  .floaters {
+    display: none;
+  }
 }
 
 @keyframes cue-gradient {
@@ -394,6 +403,13 @@ footer.pl-rail {
   overflow: visible;
 }
 
+.hero-backdrop {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
 .hero-sun {
   --sun-size: min(1100px, 92vw);
   position: absolute;
@@ -406,7 +422,7 @@ footer.pl-rail {
   background-image: var(--hero-img, url('../images/background.png'));
   background-size: cover;
   background-position: center;
-  z-index: 10;
+  z-index: 0;
   opacity: 0.9;
   filter: saturate(110%);
   -webkit-mask-image: radial-gradient(closest-side, #000 78%, transparent 100%);

--- a/pages/bonuses.html
+++ b/pages/bonuses.html
@@ -86,7 +86,7 @@
 
     <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
-        <div class="absolute inset-0 -z-10 pointer-events-none">
+        <div class="hero-backdrop">
         <div
           class="hero-sun"
           data-hero-img="../assets/images/background.png"

--- a/pages/content.html
+++ b/pages/content.html
@@ -86,7 +86,7 @@
 
     <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
-        <div class="absolute inset-0 -z-10 pointer-events-none">
+        <div class="hero-backdrop">
         <div
           class="hero-sun"
           data-hero-img="../assets/images/background.png"

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -86,7 +86,7 @@
 
     <main class="pl-rail relative z-10">
       <section class="relative pt-10 pb-14 hero-section">
-        <div class="absolute inset-0 -z-10 pointer-events-none">
+        <div class="hero-backdrop">
         <div
           class="hero-sun"
           data-hero-img="../assets/images/background.png"

--- a/pages/rewards.html
+++ b/pages/rewards.html
@@ -88,7 +88,7 @@
   <!-- Hero layer lives inside MAIN but behind the content -->
   <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
     <!-- HERO: behind heading + cards -->
-    <div class="absolute inset-0 -z-10 pointer-events-none">
+    <div class="hero-backdrop">
       <!-- swap background.png for your sun image -->
       <div
         class="hero-sun"

--- a/templates/pages/pages/bonuses.html
+++ b/templates/pages/pages/bonuses.html
@@ -1,6 +1,6 @@
 <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
-        <div class="absolute inset-0 -z-10 pointer-events-none">
+        <div class="hero-backdrop">
         <div
           class="hero-sun"
           data-hero-img="{{ASSET_BASE}}/images/background.png"

--- a/templates/pages/pages/content.html
+++ b/templates/pages/pages/content.html
@@ -1,6 +1,6 @@
 <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
-        <div class="absolute inset-0 -z-10 pointer-events-none">
+        <div class="hero-backdrop">
         <div
           class="hero-sun"
           data-hero-img="{{ASSET_BASE}}/images/background.png"

--- a/templates/pages/pages/leaderboard.html
+++ b/templates/pages/pages/leaderboard.html
@@ -1,6 +1,6 @@
 <main class="pl-rail relative z-10">
       <section class="relative pt-10 pb-14 hero-section">
-        <div class="absolute inset-0 -z-10 pointer-events-none">
+        <div class="hero-backdrop">
         <div
           class="hero-sun"
           data-hero-img="{{ASSET_BASE}}/images/background.png"

--- a/templates/pages/pages/rewards.html
+++ b/templates/pages/pages/rewards.html
@@ -2,7 +2,7 @@
   <!-- Hero layer lives inside MAIN but behind the content -->
   <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
     <!-- HERO: behind heading + cards -->
-    <div class="absolute inset-0 -z-10 pointer-events-none">
+    <div class="hero-backdrop">
       <!-- swap background.png for your sun image -->
       <div
         class="hero-sun"


### PR DESCRIPTION
## Summary
- introduce a dedicated `hero-backdrop` wrapper so hero backgrounds render correctly on leaderboard and bonus pages and keep the other pages in sync
- update responsive styles to hide the hero background image and floating artwork on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c99df4adf08332a03951296ec1190b