### PR TITLE
Align hero background positioning across pages

### DIFF
--- a/pages/bonuses.html
+++ b/pages/bonuses.html
@@ -90,7 +90,7 @@
         <div
           class="hero-sun"
           data-hero-img="../assets/images/background.png"
-          style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+          style="--hero-img: url('../assets/images/background.png')"
         ></div>
           <div class="hero-fade"></div>
         </div>

--- a/pages/content.html
+++ b/pages/content.html
@@ -90,7 +90,7 @@
         <div
           class="hero-sun"
           data-hero-img="../assets/images/background.png"
-          style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+          style="--hero-img: url('../assets/images/background.png')"
         ></div>
           <div class="hero-fade"></div>
         </div>

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -90,7 +90,7 @@
         <div
           class="hero-sun"
           data-hero-img="../assets/images/background.png"
-          style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+          style="--hero-img: url('../assets/images/background.png')"
         ></div>
           <div class="hero-fade"></div>
         </div>

--- a/pages/rewards.html
+++ b/pages/rewards.html
@@ -93,7 +93,7 @@
       <div
         class="hero-sun"
         data-hero-img="../assets/images/background.png"
-        style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"
+        style="--hero-img: url('../assets/images/background.png')"
       ></div>
       <div class="hero-fade"></div>
     </div>

--- a/templates/pages/pages/bonuses.html
+++ b/templates/pages/pages/bonuses.html
@@ -4,7 +4,7 @@
         <div
           class="hero-sun"
           data-hero-img="{{ASSET_BASE}}/images/background.png"
-          style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+          style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
         ></div>
           <div class="hero-fade"></div>
         </div>

--- a/templates/pages/pages/content.html
+++ b/templates/pages/pages/content.html
@@ -4,7 +4,7 @@
         <div
           class="hero-sun"
           data-hero-img="{{ASSET_BASE}}/images/background.png"
-          style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+          style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
         ></div>
           <div class="hero-fade"></div>
         </div>

--- a/templates/pages/pages/leaderboard.html
+++ b/templates/pages/pages/leaderboard.html
@@ -4,7 +4,7 @@
         <div
           class="hero-sun"
           data-hero-img="{{ASSET_BASE}}/images/background.png"
-          style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+          style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
         ></div>
           <div class="hero-fade"></div>
         </div>

--- a/templates/pages/pages/rewards.html
+++ b/templates/pages/pages/rewards.html
@@ -7,7 +7,7 @@
       <div
         class="hero-sun"
         data-hero-img="{{ASSET_BASE}}/images/background.png"
-        style="--hero-img: url('{{ASSET_BASE}}/images/background.png'); --sun-size: min(1200px,95vw)"
+        style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
       ></div>
       <div class="hero-fade"></div>
     </div>


### PR DESCRIPTION
## Summary
- remove the page-specific hero background sizing override so every page renders the Background.png image like the home page
- rebuild the generated HTML pages from the updated templates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a0ebad2c833288b72501ef92a523