### PR TITLE
Improve mobile layouts and remove hero backgrounds

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -454,15 +454,16 @@ window.tailwind.config = {
       wrap.innerHTML = "";
       entries.slice(3, 20).forEach((entry) => {
         const row = document.createElement("div");
-        row.className = "glass rounded-2xl p-4 grid grid-cols-[40px,1fr,1fr,120px] gap-3 items-center";
+        row.className =
+          "glass rounded-2xl p-4 grid grid-cols-[auto,1fr] sm:grid-cols-[40px,1fr,1fr,120px] gap-x-3 gap-y-2 items-start sm:items-center";
         row.innerHTML = `
           <div class="text-white/70 font-semibold">#${entry.rank}</div>
           <div class="flex items-center gap-3">
-            <div class="w-8 h-8 rounded-xl bg-white/10 grid place-items-center"><i data-lucide="user" class="w-4 h-4"></i></div>
+            <div class="grid h-8 w-8 place-items-center rounded-xl bg-white/10"><i data-lucide="user" class="h-4 w-4"></i></div>
             <div class="truncate">${entry.username}</div>
           </div>
-          <div class="text-white/80">${formatMoney(entry.total_wagered)}</div>
-          <div class="text-right"><span class="gift" aria-hidden="true">
+          <div class="col-span-2 text-right text-white/80 sm:col-span-1 sm:text-left">${formatMoney(entry.total_wagered)}</div>
+          <div class="col-span-2 flex items-center justify-end gap-2 text-right sm:col-span-1 sm:justify-end"><span class="gift" aria-hidden="true">
   <svg viewBox="0 0 24 24" class="gift-svg">
     <defs>
       <linearGradient id="gift-grad" x1="0" y1="0" x2="1" y2="1">
@@ -476,7 +477,7 @@ window.tailwind.config = {
     <path d="M12 8 c-1.6-3 -4.2-3.6 -5.2-2.1 c-.9 1.4 .6 2.8 2.9 3.4 M12 8 c1.6-3 4.2-3.6 5.2-2.1 c.9 1.4 -.6 2.8 -2.9 3.4" fill="none" stroke="var(--gift-stroke)"/>
     <circle cx="12" cy="9" r="1.2" class="fill" stroke="var(--gift-stroke)"/>
   </svg>
-</span>${formatMoney(entry.prize || 0)}</span></div>
+</span><span>${formatMoney(entry.prize || 0)}</span></div>
         `;
         wrap.appendChild(row);
       });

--- a/index.html
+++ b/index.html
@@ -114,18 +114,18 @@
           <!-- Depth-parallax stats strip -->
           <div class="mt-16 grid place-items-center">
             <div class="tilt w-full max-w-4xl">
-              <div class="relative grid grid-cols-3 gap-4">
+              <div class="relative grid w-full gap-4 sm:grid-cols-3">
                 <div class="glass rounded-3xl p-6 text-center" style="transform: translateZ(40px)">
-                  <div class="text-3xl font-bold text-white">5,000+</div>
-                  <div class="text-xs text-white/60 mt-1">Community Users</div>
+                  <div class="text-2xl font-bold text-white sm:text-3xl">5,000+</div>
+                  <div class="mt-1 text-xs text-white/60">Community Users</div>
                 </div>
                 <div class="glass rounded-3xl p-6 text-center" style="transform: translateZ(60px)">
-                  <div class="text-3xl font-bold text-white">$50,000+</div>
-                  <div class="text-xs text-white/60 mt-1">Given Away</div>
+                  <div class="text-2xl font-bold text-white sm:text-3xl">$50,000+</div>
+                  <div class="mt-1 text-xs text-white/60">Given Away</div>
                 </div>
                 <div class="glass rounded-3xl p-6 text-center" style="transform: translateZ(30px)">
-                  <div class="text-3xl font-bold text-white">100+</div>
-                  <div class="text-xs text-white/60 mt-1">Events Completed</div>
+                  <div class="text-2xl font-bold text-white sm:text-3xl">100+</div>
+                  <div class="mt-1 text-xs text-white/60">Events Completed</div>
                 </div>
               </div>
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "txplays",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "txplays",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/pages/bonuses.html
+++ b/pages/bonuses.html
@@ -87,11 +87,7 @@
     <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="hero-backdrop">
-        <div
-          class="hero-sun"
-          data-hero-img="../assets/images/background.png"
-          style="--hero-img: url('../assets/images/background.png')"
-        ></div>
+        <div class="hero-sun" style="--hero-img: none"></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">
@@ -102,9 +98,9 @@
           </div>
 
           <!-- Main bonus card -->
-          <div class="mt-10 grid lg:grid-cols-[380px,1fr] gap-6 items-stretch">
+          <div class="mt-10 grid gap-6 items-stretch lg:grid-cols-[380px,1fr]">
           <div class="glass rounded-3xl p-4 flex items-center justify-center shadow-card">
-            <img src="../assets/images/bonus.png" alt="Main Bonus" class="rounded-2xl w-full h-full object-contain"/>
+            <img src="../assets/images/bonus.png" alt="Main Bonus" class="h-full w-full rounded-2xl object-contain" />
           </div>
 
           <div class="glass rounded-3xl p-6 sm:p-8 shadow-card">
@@ -125,8 +121,8 @@
 
             <div class="mt-6 flex flex-wrap items-center gap-3">
               <!-- Bonus code copy pill -->
-              <button id="bonusCode" onclick="copyBonusCode()" class="relative group inline-flex items-center gap-2 rounded-2xl px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10">
-                <i data-lucide="clipboard" class="w-4 h-4"></i>
+              <button id="bonusCode" onclick="copyBonusCode()" class="relative group inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10">
+                <i data-lucide="clipboard" class="h-4 w-4"></i>
                 <span class="text-sm">CODE:</span>
                 <span class="text-sm font-semibold" id="bonusCodeText">TX</span>
                 <span class="pointer-events-none absolute -bottom-9 left-1/2 -translate-x-1/2 text-[12px] bg-black/70 border border-white/10 rounded-lg px-2 py-1 opacity-0 group-hover:opacity-100 transition">Click to copy</span>
@@ -142,11 +138,11 @@
 
             <!-- Terms -->
             <div class="mt-8">
-              <div class="flex items-center gap-2 text-white/80 text-sm uppercase tracking-wide">
+              <div class="flex items-center gap-2 text-sm uppercase tracking-wide text-white/80">
                 <i data-lucide="file-text" class="w-4 h-4"></i>
                 <span>Bonus Terms</span>
               </div>
-              <div class="mt-4 grid sm:grid-cols-2 gap-3">
+              <div class="mt-4 grid gap-3 sm:grid-cols-2">
                 <div class="flex items-start gap-2 text-sm text-white/70"><i data-lucide="check-circle" class="w-4 h-4 mt-0.5"></i><span>Bonus code: TX must be used</span></div>
                 <div class="flex items-start gap-2 text-sm text-white/70"><i data-lucide="check-circle" class="w-4 h-4 mt-0.5"></i><span>Minimum deposit: $20</span></div>
                 <div class="flex items-start gap-2 text-sm text-white/70"><i data-lucide="check-circle" class="w-4 h-4 mt-0.5"></i><span>35x wagering requirement (Depo+Bonus)</span></div>
@@ -156,37 +152,39 @@
               </div>
             </div>
           </div>
+          </div>
 
           <!-- Small bonuses grid -->
           <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          <div class="glass rounded-2xl p-6 text-center shadow-card">
-            <div class="text-xl font-extrabold mb-1" style="color:#60A5FA">3K Leaderboard</div>
-            <div class="text-white/80 mb-2">(Top 10 prizes)</div>
-            <div class="text-white/60">Fight amongst your friends for competitive prizes and rewards 🏆</div>
-            <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 rounded-xl px-4 py-2 inline-flex items-center gap-2 bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink">
-              <span>Learn More</span>
-            </button>
+            <div class="glass rounded-2xl p-6 text-center shadow-card">
+              <div class="mb-1 text-xl font-extrabold" style="color:#60A5FA">3K Leaderboard</div>
+              <div class="mb-2 text-white/80">(Top 10 prizes)</div>
+              <div class="text-white/60">Fight amongst your friends for competitive prizes and rewards 🏆</div>
+              <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-pink-brand to-blue-brand px-4 py-2 hover:drop-shadow-neonPink">
+                <span>Learn More</span>
+              </button>
+            </div>
+            <div class="glass rounded-2xl p-6 text-center shadow-card">
+              <div class="mb-1 text-xl font-extrabold" style="color:#A855F7">Affiliate Bonus Buys</div>
+              <div class="mb-2 text-white/80">Win bonus buys daily.</div>
+              <div class="text-white/60">Based on your play, you can receive random bonus buys from TX.</div>
+              <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-pink-brand to-blue-brand px-4 py-2 hover:drop-shadow-neonPink">
+                <span>Learn More</span>
+              </button>
+            </div>
+            <div class="glass rounded-2xl p-6 text-center shadow-card">
+              <div class="mb-1 text-xl font-extrabold" style="color:#F59E0B">Cash Events</div>
+              <div class="mb-2 text-white/80">Access events worth $1,000s of dollars.</div>
+              <div class="text-white/60">Participate periodically in community cash events.</div>
+              <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-pink-brand to-blue-brand px-4 py-2 hover:drop-shadow-neonPink">
+                <span>Learn More</span>
+              </button>
+            </div>
           </div>
-          <div class="glass rounded-2xl p-6 text-center shadow-card">
-            <div class="text-xl font-extrabold mb-1" style="color:#A855F7">Affiliate Bonus Buys</div>
-            <div class="text-white/80 mb-2">Win bonus buys daily.</div>
-            <div class="text-white/60">Based on your play, you can receive random bonus buys from TX.</div>
-            <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 rounded-xl px-4 py-2 inline-flex items-center gap-2 bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink">
-              <span>Learn More</span>
-            </button>
-          </div>
-          <div class="glass rounded-2xl p-6 text-center shadow-card">
-            <div class="text-xl font-extrabold mb-1" style="color:#F59E0B">Cash Events</div>
-            <div class="text-white/80 mb-2">Access events worth $1,000s of dollars.</div>
-            <div class="text-white/60">Participate periodically in community cash events.</div>
-            <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 rounded-xl px-4 py-2 inline-flex items-center gap-2 bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink">
-            </i><span>Learn More</span>
-            </button>
-          </div>
-        </div>
         </div>
       </section>
     </main>
+
         <!-- FOOTER -->
     <footer class="pl-rail border-t border-white/10 relative z-10">
       <div class="max-w-7xl mx-auto px-6 py-10 grid gap-8 sm:grid-cols-3">

--- a/pages/content.html
+++ b/pages/content.html
@@ -87,11 +87,7 @@
     <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="hero-backdrop">
-        <div
-          class="hero-sun"
-          data-hero-img="../assets/images/background.png"
-          style="--hero-img: url('../assets/images/background.png')"
-        ></div>
+        <div class="hero-sun" style="--hero-img: none"></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">
@@ -241,6 +237,7 @@
         </div>
       </section>
     </main>
+
         <!-- FOOTER -->
     <footer class="pl-rail border-t border-white/10 relative z-10">
       <div class="max-w-7xl mx-auto px-6 py-10 grid gap-8 sm:grid-cols-3">

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -87,11 +87,7 @@
     <main class="pl-rail relative z-10">
       <section class="relative pt-10 pb-14 hero-section">
         <div class="hero-backdrop">
-        <div
-          class="hero-sun"
-          data-hero-img="../assets/images/background.png"
-          style="--hero-img: url('../assets/images/background.png')"
-        ></div>
+        <div class="hero-sun" style="--hero-img: none"></div>
           <div class="hero-fade"></div>
         </div>
         <div class="max-w-7xl mx-auto px-6 relative z-10">
@@ -270,22 +266,22 @@
 
           <!-- Countdown -->
           <div class="mt-10 grid">
-            <div class="glass rounded-3xl p-6 flex flex-col sm:flex-row items-center justify-between gap-4">
-              <div class="flex items-center gap-3">
-                <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-indigo to-violet grid place-items-center"><i data-lucide="hourglass" class="w-5 h-5"></i></div>
+            <div class="glass rounded-3xl p-6 flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex items-start gap-3 text-center sm:items-center sm:text-left">
+                <div class="grid h-10 w-10 place-items-center rounded-xl bg-gradient-to-br from-indigo to-violet"><i data-lucide="hourglass" class="h-5 w-5"></i></div>
                 <div class="text-sm">
                   <div class="font-semibold">Time left to Wager</div>
                   <div class="text-white/60" id="countdown-sub">Resets Monthly 00:00 (CST)</div>
                 </div>
               </div>
-              <div class="flex items-center gap-3 text-center">
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="d">0</div><div class="text-xs text-white/60">D</div></div>
-                <div class="text-white/30">:</div>
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="h">00</div><div class="text-xs text-white/60">H</div></div>
-                <div class="text-white/30">:</div>
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="m">00</div><div class="text-xs text-white/60">M</div></div>
-                <div class="text-white/30">:</div>
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="s">00</div><div class="text-xs text-white/60">S</div></div>
+              <div class="flex w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 text-center sm:w-auto sm:gap-4">
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="d">0</div><div class="text-xs text-white/60">D</div></div>
+                <div class="hidden text-white/30 sm:block">:</div>
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="h">00</div><div class="text-xs text-white/60">H</div></div>
+                <div class="hidden text-white/30 sm:block">:</div>
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="m">00</div><div class="text-xs text-white/60">M</div></div>
+                <div class="hidden text-white/30 sm:block">:</div>
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="s">00</div><div class="text-xs text-white/60">S</div></div>
               </div>
             </div>
           </div>
@@ -319,6 +315,7 @@
         </div>
       </section>
     </main>
+
         <!-- FOOTER -->
     <footer class="pl-rail border-t border-white/10 relative z-10">
       <div class="max-w-7xl mx-auto px-6 py-10 grid gap-8 sm:grid-cols-3">

--- a/pages/rewards.html
+++ b/pages/rewards.html
@@ -89,12 +89,8 @@
   <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
     <!-- HERO: behind heading + cards -->
     <div class="hero-backdrop">
-      <!-- swap background.png for your sun image -->
-      <div
-        class="hero-sun"
-        data-hero-img="../assets/images/background.png"
-        style="--hero-img: url('../assets/images/background.png')"
-      ></div>
+      <!-- Hero highlight (custom background optional) -->
+        <div class="hero-sun" style="--hero-img: none"></div>
       <div class="hero-fade"></div>
     </div>
 
@@ -133,6 +129,7 @@
     </div>
   </section>
 </main>
+
         <!-- FOOTER -->
     <footer class="pl-rail border-t border-white/10 relative z-10">
       <div class="max-w-7xl mx-auto px-6 py-10 grid gap-8 sm:grid-cols-3">

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -28,18 +28,18 @@
           <!-- Depth-parallax stats strip -->
           <div class="mt-16 grid place-items-center">
             <div class="tilt w-full max-w-4xl">
-              <div class="relative grid grid-cols-3 gap-4">
+              <div class="relative grid w-full gap-4 sm:grid-cols-3">
                 <div class="glass rounded-3xl p-6 text-center" style="transform: translateZ(40px)">
-                  <div class="text-3xl font-bold text-white">5,000+</div>
-                  <div class="text-xs text-white/60 mt-1">Community Users</div>
+                  <div class="text-2xl font-bold text-white sm:text-3xl">5,000+</div>
+                  <div class="mt-1 text-xs text-white/60">Community Users</div>
                 </div>
                 <div class="glass rounded-3xl p-6 text-center" style="transform: translateZ(60px)">
-                  <div class="text-3xl font-bold text-white">$50,000+</div>
-                  <div class="text-xs text-white/60 mt-1">Given Away</div>
+                  <div class="text-2xl font-bold text-white sm:text-3xl">$50,000+</div>
+                  <div class="mt-1 text-xs text-white/60">Given Away</div>
                 </div>
                 <div class="glass rounded-3xl p-6 text-center" style="transform: translateZ(30px)">
-                  <div class="text-3xl font-bold text-white">100+</div>
-                  <div class="text-xs text-white/60 mt-1">Events Completed</div>
+                  <div class="text-2xl font-bold text-white sm:text-3xl">100+</div>
+                  <div class="mt-1 text-xs text-white/60">Events Completed</div>
                 </div>
               </div>
             </div>

--- a/templates/pages/pages/bonuses.html
+++ b/templates/pages/pages/bonuses.html
@@ -1,11 +1,7 @@
 <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="hero-backdrop">
-        <div
-          class="hero-sun"
-          data-hero-img="{{ASSET_BASE}}/images/background.png"
-          style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
-        ></div>
+        <div class="hero-sun" style="--hero-img: none"></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">
@@ -16,9 +12,9 @@
           </div>
 
           <!-- Main bonus card -->
-          <div class="mt-10 grid lg:grid-cols-[380px,1fr] gap-6 items-stretch">
+          <div class="mt-10 grid gap-6 items-stretch lg:grid-cols-[380px,1fr]">
           <div class="glass rounded-3xl p-4 flex items-center justify-center shadow-card">
-            <img src="{{ASSET_BASE}}/images/bonus.png" alt="Main Bonus" class="rounded-2xl w-full h-full object-contain"/>
+            <img src="{{ASSET_BASE}}/images/bonus.png" alt="Main Bonus" class="h-full w-full rounded-2xl object-contain" />
           </div>
 
           <div class="glass rounded-3xl p-6 sm:p-8 shadow-card">
@@ -39,8 +35,8 @@
 
             <div class="mt-6 flex flex-wrap items-center gap-3">
               <!-- Bonus code copy pill -->
-              <button id="bonusCode" onclick="copyBonusCode()" class="relative group inline-flex items-center gap-2 rounded-2xl px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10">
-                <i data-lucide="clipboard" class="w-4 h-4"></i>
+              <button id="bonusCode" onclick="copyBonusCode()" class="relative group inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10">
+                <i data-lucide="clipboard" class="h-4 w-4"></i>
                 <span class="text-sm">CODE:</span>
                 <span class="text-sm font-semibold" id="bonusCodeText">TX</span>
                 <span class="pointer-events-none absolute -bottom-9 left-1/2 -translate-x-1/2 text-[12px] bg-black/70 border border-white/10 rounded-lg px-2 py-1 opacity-0 group-hover:opacity-100 transition">Click to copy</span>
@@ -56,11 +52,11 @@
 
             <!-- Terms -->
             <div class="mt-8">
-              <div class="flex items-center gap-2 text-white/80 text-sm uppercase tracking-wide">
+              <div class="flex items-center gap-2 text-sm uppercase tracking-wide text-white/80">
                 <i data-lucide="file-text" class="w-4 h-4"></i>
                 <span>Bonus Terms</span>
               </div>
-              <div class="mt-4 grid sm:grid-cols-2 gap-3">
+              <div class="mt-4 grid gap-3 sm:grid-cols-2">
                 <div class="flex items-start gap-2 text-sm text-white/70"><i data-lucide="check-circle" class="w-4 h-4 mt-0.5"></i><span>Bonus code: TX must be used</span></div>
                 <div class="flex items-start gap-2 text-sm text-white/70"><i data-lucide="check-circle" class="w-4 h-4 mt-0.5"></i><span>Minimum deposit: $20</span></div>
                 <div class="flex items-start gap-2 text-sm text-white/70"><i data-lucide="check-circle" class="w-4 h-4 mt-0.5"></i><span>35x wagering requirement (Depo+Bonus)</span></div>
@@ -70,34 +66,35 @@
               </div>
             </div>
           </div>
+          </div>
 
           <!-- Small bonuses grid -->
           <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          <div class="glass rounded-2xl p-6 text-center shadow-card">
-            <div class="text-xl font-extrabold mb-1" style="color:#60A5FA">3K Leaderboard</div>
-            <div class="text-white/80 mb-2">(Top 10 prizes)</div>
-            <div class="text-white/60">Fight amongst your friends for competitive prizes and rewards 🏆</div>
-            <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 rounded-xl px-4 py-2 inline-flex items-center gap-2 bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink">
-              <span>Learn More</span>
-            </button>
+            <div class="glass rounded-2xl p-6 text-center shadow-card">
+              <div class="mb-1 text-xl font-extrabold" style="color:#60A5FA">3K Leaderboard</div>
+              <div class="mb-2 text-white/80">(Top 10 prizes)</div>
+              <div class="text-white/60">Fight amongst your friends for competitive prizes and rewards 🏆</div>
+              <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-pink-brand to-blue-brand px-4 py-2 hover:drop-shadow-neonPink">
+                <span>Learn More</span>
+              </button>
+            </div>
+            <div class="glass rounded-2xl p-6 text-center shadow-card">
+              <div class="mb-1 text-xl font-extrabold" style="color:#A855F7">Affiliate Bonus Buys</div>
+              <div class="mb-2 text-white/80">Win bonus buys daily.</div>
+              <div class="text-white/60">Based on your play, you can receive random bonus buys from TX.</div>
+              <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-pink-brand to-blue-brand px-4 py-2 hover:drop-shadow-neonPink">
+                <span>Learn More</span>
+              </button>
+            </div>
+            <div class="glass rounded-2xl p-6 text-center shadow-card">
+              <div class="mb-1 text-xl font-extrabold" style="color:#F59E0B">Cash Events</div>
+              <div class="mb-2 text-white/80">Access events worth $1,000s of dollars.</div>
+              <div class="text-white/60">Participate periodically in community cash events.</div>
+              <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-pink-brand to-blue-brand px-4 py-2 hover:drop-shadow-neonPink">
+                <span>Learn More</span>
+              </button>
+            </div>
           </div>
-          <div class="glass rounded-2xl p-6 text-center shadow-card">
-            <div class="text-xl font-extrabold mb-1" style="color:#A855F7">Affiliate Bonus Buys</div>
-            <div class="text-white/80 mb-2">Win bonus buys daily.</div>
-            <div class="text-white/60">Based on your play, you can receive random bonus buys from TX.</div>
-            <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 rounded-xl px-4 py-2 inline-flex items-center gap-2 bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink">
-              <span>Learn More</span>
-            </button>
-          </div>
-          <div class="glass rounded-2xl p-6 text-center shadow-card">
-            <div class="text-xl font-extrabold mb-1" style="color:#F59E0B">Cash Events</div>
-            <div class="text-white/80 mb-2">Access events worth $1,000s of dollars.</div>
-            <div class="text-white/60">Participate periodically in community cash events.</div>
-            <button onclick="window.open('https://discord.gg/txplays','_blank')" class="mt-4 rounded-xl px-4 py-2 inline-flex items-center gap-2 bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink">
-            </i><span>Learn More</span>
-            </button>
-          </div>
-        </div>
         </div>
       </section>
     </main>

--- a/templates/pages/pages/content.html
+++ b/templates/pages/pages/content.html
@@ -1,11 +1,7 @@
 <main class="pl-rail relative z-10 pb-20">
       <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
         <div class="hero-backdrop">
-        <div
-          class="hero-sun"
-          data-hero-img="{{ASSET_BASE}}/images/background.png"
-          style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
-        ></div>
+        <div class="hero-sun" style="--hero-img: none"></div>
           <div class="hero-fade"></div>
         </div>
         <div class="relative z-10">

--- a/templates/pages/pages/leaderboard.html
+++ b/templates/pages/pages/leaderboard.html
@@ -1,11 +1,7 @@
 <main class="pl-rail relative z-10">
       <section class="relative pt-10 pb-14 hero-section">
         <div class="hero-backdrop">
-        <div
-          class="hero-sun"
-          data-hero-img="{{ASSET_BASE}}/images/background.png"
-          style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
-        ></div>
+        <div class="hero-sun" style="--hero-img: none"></div>
           <div class="hero-fade"></div>
         </div>
         <div class="max-w-7xl mx-auto px-6 relative z-10">
@@ -184,22 +180,22 @@
 
           <!-- Countdown -->
           <div class="mt-10 grid">
-            <div class="glass rounded-3xl p-6 flex flex-col sm:flex-row items-center justify-between gap-4">
-              <div class="flex items-center gap-3">
-                <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-indigo to-violet grid place-items-center"><i data-lucide="hourglass" class="w-5 h-5"></i></div>
+            <div class="glass rounded-3xl p-6 flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex items-start gap-3 text-center sm:items-center sm:text-left">
+                <div class="grid h-10 w-10 place-items-center rounded-xl bg-gradient-to-br from-indigo to-violet"><i data-lucide="hourglass" class="h-5 w-5"></i></div>
                 <div class="text-sm">
                   <div class="font-semibold">Time left to Wager</div>
                   <div class="text-white/60" id="countdown-sub">Resets Monthly 00:00 (CST)</div>
                 </div>
               </div>
-              <div class="flex items-center gap-3 text-center">
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="d">0</div><div class="text-xs text-white/60">D</div></div>
-                <div class="text-white/30">:</div>
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="h">00</div><div class="text-xs text-white/60">H</div></div>
-                <div class="text-white/30">:</div>
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="m">00</div><div class="text-xs text-white/60">M</div></div>
-                <div class="text-white/30">:</div>
-                <div class="min-w-[70px]"><div class="text-3xl font-extrabold flip" id="s">00</div><div class="text-xs text-white/60">S</div></div>
+              <div class="flex w-full flex-wrap items-center justify-center gap-x-3 gap-y-2 text-center sm:w-auto sm:gap-4">
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="d">0</div><div class="text-xs text-white/60">D</div></div>
+                <div class="hidden text-white/30 sm:block">:</div>
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="h">00</div><div class="text-xs text-white/60">H</div></div>
+                <div class="hidden text-white/30 sm:block">:</div>
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="m">00</div><div class="text-xs text-white/60">M</div></div>
+                <div class="hidden text-white/30 sm:block">:</div>
+                <div class="min-w-[56px]"><div class="text-2xl font-extrabold flip sm:text-3xl" id="s">00</div><div class="text-xs text-white/60">S</div></div>
               </div>
             </div>
           </div>

--- a/templates/pages/pages/rewards.html
+++ b/templates/pages/pages/rewards.html
@@ -3,12 +3,8 @@
   <section class="max-w-7xl mx-auto px-6 pt-12 hero-section">
     <!-- HERO: behind heading + cards -->
     <div class="hero-backdrop">
-      <!-- swap background.png for your sun image -->
-      <div
-        class="hero-sun"
-        data-hero-img="{{ASSET_BASE}}/images/background.png"
-        style="--hero-img: url('{{ASSET_BASE}}/images/background.png')"
-      ></div>
+      <!-- Hero highlight (custom background optional) -->
+        <div class="hero-sun" style="--hero-img: none"></div>
       <div class="hero-fade"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove the hero background image from non-home pages while keeping the component available for optional customization
- tighten the home stats grid typography so the numbers scale down on small screens
- rework the leaderboard countdown markup and generated rows to display cleanly on mobile
- reorganize the bonuses cards layout so the "learn more" boxes expand to full width on desktop

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a3bdbd44833299276afd5ec7cd9d