### PR TITLE
Add Discord OAuth login with profile modal

### DIFF
--- a/assets/scripts/auth-config.js
+++ b/assets/scripts/auth-config.js
@@ -1,0 +1,22 @@
+/**
+ * Discord OAuth configuration for the TxPlays front-end.
+ *
+ * Replace the placeholder values below with the credentials from your
+ * Discord application at https://discord.com/developers/applications.
+ *
+ * Required values:
+ *  - clientId:       The "Application ID" from the General Information tab.
+ *  - redirectUri:    One of the Redirects you add under the OAuth2 section.
+ *                     This must exactly match the URL of the page that should
+ *                     receive the Discord OAuth response (including protocol).
+ *  - scopes:         The OAuth scopes to request. "identify" is enough for
+ *                     this integration because we only need basic profile data.
+ *
+ * You can override these values at runtime before main.js loads if you prefer
+ * to inject environment-specific settings.
+ */
+window.__DISCORD_AUTH_CONFIG__ = window.__DISCORD_AUTH_CONFIG__ || {
+  clientId: "YOUR_DISCORD_CLIENT_ID",
+  redirectUri: "https://your-domain.example/index.html",
+  scopes: ["identify"]
+};

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -129,6 +129,237 @@ body {
   transition: transform 0.08s ease;
 }
 
+/* ===== Profile modal ===== */
+.profile-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: rgba(6, 9, 18, 0.82);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 120;
+}
+
+.profile-modal-backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.profile-modal-backdrop .profile-modal {
+  position: relative;
+  width: min(420px, 100%);
+  padding: 2.25rem;
+  border-radius: 1.5rem;
+  background: rgba(12, 16, 26, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+  color: #fff;
+  opacity: 0;
+  transform: translateY(28px) scale(0.97);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.profile-modal-backdrop.is-open .profile-modal {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.profile-modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.profile-modal-close:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: scale(1.05);
+}
+
+.profile-modal-close span {
+  font-size: 1.2rem;
+  line-height: 1;
+  transform: translateY(-1px);
+}
+
+.profile-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.profile-modal-avatar {
+  width: 4.2rem;
+  height: 4.2rem;
+  border-radius: 9999px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-modal-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-modal-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.profile-modal-overline {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.55);
+  margin: 0;
+}
+
+.profile-modal-meta h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.profile-modal-username {
+  font-size: 0.92rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin: 0;
+}
+
+.profile-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.profile-modal-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.profile-modal-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.profile-modal-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  word-break: break-word;
+}
+
+.profile-modal-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #8ab4ff;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.profile-modal-link:hover {
+  color: #bfd4ff;
+}
+
+.profile-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-input-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-input-group input {
+  flex: 1;
+  border-radius: 9999px;
+  padding: 0.75rem 1.1rem;
+  background: rgba(13, 16, 26, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-input-group input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.profile-input-group input:focus {
+  outline: none;
+  border-color: rgba(88, 101, 242, 0.85);
+  box-shadow: 0 0 0 3px rgba(88, 101, 242, 0.24);
+}
+
+.profile-input-group button {
+  border: none;
+  border-radius: 9999px;
+  padding: 0.7rem 1.4rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #5865f2, #7c3aed);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.profile-input-group button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(88, 101, 242, 0.35);
+}
+
+.profile-input-group button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.profile-status {
+  font-size: 0.8rem;
+  color: rgba(131, 216, 247, 0.9);
+  margin: 0;
+}
+
+.profile-status.is-error {
+  color: rgba(255, 125, 125, 0.92);
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
 /* ===== Scrollbars ===== */
 ::-webkit-scrollbar {
   width: 10px;

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="assets/scripts/auth-config.js"></script>
     <script src="assets/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->
@@ -52,6 +53,10 @@
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
+        <a href="/events" class="nav-item" aria-label="Events" style="--accent:#8B5CF6">
+          <span class="nav-bubble"><i data-lucide="calendar"></i></span>
+          <span class="nav-label">Events</span>
+        </a>
         <a href="pages/content.html" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
@@ -73,10 +78,12 @@
         </div>
 
         <!-- Discord-style Login button -->
-        <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
-          <span>Login</span>
-          <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
-        </a>
+        <div data-auth-root class="auth-controls relative flex items-center gap-2">
+          <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
+            <span>Login</span>
+            <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
+          </a>
+        </div>
       </div>
     </header>
 
@@ -93,8 +100,8 @@
           <div class="inline-flex items-center justify-center w-48 h-48 rounded-[2rem] overflow-hidden">
             <img src="assets/images/crown.png" alt="Your Logo" class="w-300 h-300 object-cover rounded-lg">
           </div>
-          <h1 class="mt-8 text-3xl sm:text-7xl font-extrabold leading-tight tracking-tight">
-            <span class="bg-clip-text text-transparent bg-gradient-to-r from-blue-brand via-violet to-pink-brand">TXPLAYS REWARDS</span>
+          <h1 class="mt-8 text-5xl sm:text-7xl font-extrabold leading-tight tracking-tight">
+            <span class="bg-clip-text text-transparent bg-gradient-to-r from-blue-brand via-violet to-pink-brand">True Rewards</span>
           </h1>
           <p class="mt-5 text-white/70 max-w-2xl mx-auto">Welcome to TRUE Rewards designed by a TRUE Player. Leaderboards, Challenges and an Active Community for all things Casino.</p>
 

--- a/pages/bonuses.html
+++ b/pages/bonuses.html
@@ -17,6 +17,7 @@
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../assets/scripts/auth-config.js"></script>
     <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->
@@ -52,6 +53,10 @@
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
+        <a href="/events" class="nav-item" aria-label="Events" style="--accent:#8B5CF6">
+          <span class="nav-bubble"><i data-lucide="calendar"></i></span>
+          <span class="nav-label">Events</span>
+        </a>
         <a href="content.html" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
@@ -73,10 +78,12 @@
         </div>
 
         <!-- Discord-style Login button -->
-        <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
-          <span>Login</span>
-          <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
-        </a>
+        <div data-auth-root class="auth-controls relative flex items-center gap-2">
+          <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
+            <span>Login</span>
+            <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
+          </a>
+        </div>
       </div>
     </header>
 

--- a/pages/content.html
+++ b/pages/content.html
@@ -17,6 +17,7 @@
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../assets/scripts/auth-config.js"></script>
     <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->
@@ -52,6 +53,10 @@
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
+        <a href="/events" class="nav-item" aria-label="Events" style="--accent:#8B5CF6">
+          <span class="nav-bubble"><i data-lucide="calendar"></i></span>
+          <span class="nav-label">Events</span>
+        </a>
         <a class="nav-item is-active" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
@@ -73,10 +78,12 @@
         </div>
 
         <!-- Discord-style Login button -->
-        <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
-          <span>Login</span>
-          <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
-        </a>
+        <div data-auth-root class="auth-controls relative flex items-center gap-2">
+          <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
+            <span>Login</span>
+            <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
+          </a>
+        </div>
       </div>
     </header>
 

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -17,6 +17,7 @@
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../assets/scripts/auth-config.js"></script>
     <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->
@@ -52,6 +53,10 @@
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
+        <a href="/events" class="nav-item" aria-label="Events" style="--accent:#8B5CF6">
+          <span class="nav-bubble"><i data-lucide="calendar"></i></span>
+          <span class="nav-label">Events</span>
+        </a>
         <a href="content.html" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
@@ -73,10 +78,12 @@
         </div>
 
         <!-- Discord-style Login button -->
-        <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-8 py-3 text-sm font-medium bg-discord hover:bg-discordDark transition-colors">
-          <span>Login</span>
-          <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
-        </a>
+        <div data-auth-root class="auth-controls relative flex items-center gap-2">
+          <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-8 py-3 text-sm font-medium bg-discord hover:bg-discordDark transition-colors">
+            <span>Login</span>
+            <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
+          </a>
+        </div>
       </div>
     </header>
 

--- a/pages/rewards.html
+++ b/pages/rewards.html
@@ -17,6 +17,7 @@
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../assets/scripts/auth-config.js"></script>
     <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->
@@ -52,6 +53,10 @@
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
+        <a href="/events" class="nav-item" aria-label="Events" style="--accent:#8B5CF6">
+          <span class="nav-bubble"><i data-lucide="calendar"></i></span>
+          <span class="nav-label">Events</span>
+        </a>
         <a href="content.html" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
@@ -73,10 +78,12 @@
         </div>
 
         <!-- Discord-style Login button -->
-        <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
-          <span>Login</span>
-          <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
-        </a>
+        <div data-auth-root class="auth-controls relative flex items-center gap-2">
+          <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
+            <span>Login</span>
+            <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
+          </a>
+        </div>
       </div>
     </header>
 

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -15,6 +15,7 @@
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="{{ASSET_BASE}}/scripts/auth-config.js"></script>
     <script src="{{ASSET_BASE}}/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -8,9 +8,11 @@
         </div>
 
         <!-- Discord-style Login button -->
-        <a href="#discord-login" class="{{LOGIN_BUTTON_CLASS}}">
-          <span>Login</span>
-          <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
-        </a>
+        <div data-auth-root class="auth-controls relative flex items-center gap-2">
+          <a href="#discord-login" class="{{LOGIN_BUTTON_CLASS}}">
+            <span>Login</span>
+            <span class="absolute -inset-px rounded-xl ring-1 ring-white/10"></span>
+          </a>
+        </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add configurable Discord OAuth front-end integration that persists sessions and updates header controls
- create a reusable profile modal for Discord account details and storing a Shuffle username
- include the auth configuration loader in all templates and regenerate the built pages

## Testing
- node build.js

------
https://chatgpt.com/codex/tasks/task_e_68c9b6aead308332a67645a422c4ed38